### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/0xCCF4/UntrustedValue/compare/v0.1.0...v0.1.1) - 2024-07-14
+
+### Added
+- accept also Insecure = Trusted types for MaybeUntrusted
+
+### Other
+- release plz should now work
+- run cargo fmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "untrusted_value"
-version = "0.1.0"
+version = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 readme = "README.md"
 keywords = ["security", "sanitization", "validation"]


### PR DESCRIPTION
## 🤖 New release
* `untrusted_value`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/0xCCF4/UntrustedValue/compare/v0.1.0...v0.1.1) - 2024-07-14

### Added
- accept also Insecure = Trusted types for MaybeUntrusted

### Other
- release plz should now work
- run cargo fmt
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).