### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/0xCCF4/UntrustedValue/compare/v0.1.1...v0.1.2) - 2024-07-15
+
+### Added
+- added sanitize_with function
+
+### Fixed
+- *(ci)* attest build provenance now points to correct path
+
+### Other
+- run cargo clippy
+
 ## [0.1.1](https://github.com/0xCCF4/UntrustedValue/compare/v0.1.0...v0.1.1) - 2024-07-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "untrusted_value"
-version = "0.1.1"
+version = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 readme = "README.md"
 keywords = ["security", "sanitization", "validation"]


### PR DESCRIPTION
## 🤖 New release
* `untrusted_value`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/0xCCF4/UntrustedValue/compare/v0.1.1...v0.1.2) - 2024-07-15

### Added
- added sanitize_with function

### Fixed
- *(ci)* attest build provenance now points to correct path

### Other
- run cargo clippy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).