### PR TITLE
chore: release

### DIFF
--- a/untrusted_value/CHANGELOG.md
+++ b/untrusted_value/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.3](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.1.2...untrusted_value-v0.1.3) - 2024-07-15
+
+### Added
+- added UntrustedVariant proc macro
+
+### Fixed
+- include derive internals even if derive feature is off
+- *(doc)* fixed doctests
+
+### Other
+- added cargo.toml documentation
+- updated documentation to reflect newly added proc macro

--- a/untrusted_value/Cargo.toml
+++ b/untrusted_value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation"]

--- a/untrusted_value_derive/CHANGELOG.md
+++ b/untrusted_value_derive/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.1.0...untrusted_value_derive-v0.1.1) - 2024-07-15
+
+### Fixed
+- *(doc)* fixed doctests

--- a/untrusted_value_derive/Cargo.toml
+++ b/untrusted_value_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value_derive"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation"]

--- a/untrusted_value_derive_internals/CHANGELOG.md
+++ b/untrusted_value_derive_internals/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive_internals-v0.1.0...untrusted_value_derive_internals-v0.1.1) - 2024-07-15
+
+### Fixed
+- *(doc)* fixed doctests

--- a/untrusted_value_derive_internals/Cargo.toml
+++ b/untrusted_value_derive_internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value_derive_internals"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation"]


### PR DESCRIPTION
## 🤖 New release
* `untrusted_value`: 0.1.2 -> 0.1.3
* `untrusted_value_derive`: 0.1.0 -> 0.1.1
* `untrusted_value_derive_internals`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `untrusted_value`
<blockquote>

## [0.1.3](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.1.2...untrusted_value-v0.1.3) - 2024-07-15

### Added
- added UntrustedVariant proc macro

### Fixed
- include derive internals even if derive feature is off
- *(doc)* fixed doctests

### Other
- added cargo.toml documentation
- updated documentation to reflect newly added proc macro
</blockquote>

## `untrusted_value_derive`
<blockquote>

## [0.1.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.1.0...untrusted_value_derive-v0.1.1) - 2024-07-15

### Fixed
- *(doc)* fixed doctests
</blockquote>

## `untrusted_value_derive_internals`
<blockquote>

## [0.1.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive_internals-v0.1.0...untrusted_value_derive_internals-v0.1.1) - 2024-07-15

### Fixed
- *(doc)* fixed doctests
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).