### PR TITLE
chore: release

### DIFF
--- a/untrusted_value/CHANGELOG.md
+++ b/untrusted_value/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.1.3...untrusted_value-v0.2.0) - 2024-07-17
+
+### Added
+- Added #[untrusted_inputs] func macro
+- [**breaking**] Added derive macro for SanitizeValue and option to add derive macros for the UntrustedVariant using #[untrusted_derive(...)]
+
+### Other
+- added keywords taint, static-analysis
+
 ## [0.1.3](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.1.2...untrusted_value-v0.1.3) - 2024-07-15
 
 ### Added

--- a/untrusted_value/Cargo.toml
+++ b/untrusted_value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation", "taint", "static-analyis"]
@@ -12,8 +12,8 @@ description = """This crate aim to provide a type-safe way to handle and sanitiz
 like user input."""
 
 [dependencies]
-untrusted_value_derive = {version = "0.1.0", optional = true, path = "../untrusted_value_derive"}
-untrusted_value_derive_internals = {version = "0.1.0", path = "../untrusted_value_derive_internals"}
+untrusted_value_derive = { version = "0.2.0", optional = true, path = "../untrusted_value_derive"}
+untrusted_value_derive_internals = { version = "0.2.0", path = "../untrusted_value_derive_internals"}
 
 [features]
 allow_usage_without_sanitization = []

--- a/untrusted_value_derive/CHANGELOG.md
+++ b/untrusted_value_derive/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.1.1...untrusted_value_derive-v0.2.0) - 2024-07-17
+
+### Added
+- Added #[untrusted_inputs] func macro
+- [**breaking**] Added derive macro for SanitizeValue and option to add derive macros for the UntrustedVariant using #[untrusted_derive(...)]
+
+### Fixed
+- fixed typo in derive_sanitize_harden implementation
+
+### Other
+- added keywords taint, static-analysis
+- changes macro path to untrusted_value to absolute
+- fixed failing doc tests
+
 ## [0.1.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.1.0...untrusted_value_derive-v0.1.1) - 2024-07-15
 
 ### Fixed

--- a/untrusted_value_derive/Cargo.toml
+++ b/untrusted_value_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value_derive"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation", "taint", "static-analyis"]

--- a/untrusted_value_derive_internals/CHANGELOG.md
+++ b/untrusted_value_derive_internals/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive_internals-v0.1.1...untrusted_value_derive_internals-v0.2.0) - 2024-07-17
+
+### Added
+- Added #[untrusted_inputs] func macro
+- [**breaking**] Added derive macro for SanitizeValue and option to add derive macros for the UntrustedVariant using #[untrusted_derive(...)]
+
+### Other
+- added keywords taint, static-analysis
+
 ## [0.1.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive_internals-v0.1.0...untrusted_value_derive_internals-v0.1.1) - 2024-07-15
 
 ### Fixed

--- a/untrusted_value_derive_internals/Cargo.toml
+++ b/untrusted_value_derive_internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value_derive_internals"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation", "taint", "static-analyis"]


### PR DESCRIPTION
## 🤖 New release
* `untrusted_value`: 0.1.3 -> 0.2.0
* `untrusted_value_derive`: 0.1.1 -> 0.2.0
* `untrusted_value_derive_internals`: 0.1.1 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `untrusted_value`
<blockquote>

## [0.2.0](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.1.3...untrusted_value-v0.2.0) - 2024-07-17

### Added
- Added #[untrusted_inputs] func macro
- [**breaking**] Added derive macro for SanitizeValue and option to add derive macros for the UntrustedVariant using #[untrusted_derive(...)]

### Other
- added keywords taint, static-analysis
</blockquote>

## `untrusted_value_derive`
<blockquote>

## [0.2.0](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.1.1...untrusted_value_derive-v0.2.0) - 2024-07-17

### Added
- Added #[untrusted_inputs] func macro
- [**breaking**] Added derive macro for SanitizeValue and option to add derive macros for the UntrustedVariant using #[untrusted_derive(...)]

### Fixed
- fixed typo in derive_sanitize_harden implementation

### Other
- added keywords taint, static-analysis
- changes macro path to untrusted_value to absolute
- fixed failing doc tests
</blockquote>

## `untrusted_value_derive_internals`
<blockquote>

## [0.2.0](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive_internals-v0.1.1...untrusted_value_derive_internals-v0.2.0) - 2024-07-17

### Added
- Added #[untrusted_inputs] func macro
- [**breaking**] Added derive macro for SanitizeValue and option to add derive macros for the UntrustedVariant using #[untrusted_derive(...)]

### Other
- added keywords taint, static-analysis
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).