### PR TITLE
chore: release

### DIFF
--- a/untrusted_value/CHANGELOG.md
+++ b/untrusted_value/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.2.1...untrusted_value-v0.2.2) - 2024-07-18
+
+### Added
+- introduced macro require_tainting
+
+### Other
+- moved traits/structs into own file each
+
 ## [0.2.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.2.0...untrusted_value-v0.2.1) - 2024-07-17
 
 ### Fixed

--- a/untrusted_value/Cargo.toml
+++ b/untrusted_value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation", "taint", "static-analyis"]
@@ -12,8 +12,8 @@ description = """This crate aim to provide a type-safe way to handle and sanitiz
 like user input."""
 
 [dependencies]
-untrusted_value_derive = { version = "0.2.1", optional = true, path = "../untrusted_value_derive"}
-untrusted_value_derive_internals = { version = "0.2.1", path = "../untrusted_value_derive_internals"}
+untrusted_value_derive = { version = "0.2.2", optional = true, path = "../untrusted_value_derive"}
+untrusted_value_derive_internals = { version = "0.2.2", path = "../untrusted_value_derive_internals"}
 
 [features]
 allow_usage_without_sanitization = []

--- a/untrusted_value_derive/CHANGELOG.md
+++ b/untrusted_value_derive/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.2.1...untrusted_value_derive-v0.2.2) - 2024-07-18
+
+### Added
+- introduced macro require_tainting
+
+### Other
+- moved traits/structs into own file each
+
 ## [0.2.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.2.0...untrusted_value_derive-v0.2.1) - 2024-07-17
 
 ### Fixed

--- a/untrusted_value_derive/Cargo.toml
+++ b/untrusted_value_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value_derive"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation", "taint", "static-analyis"]

--- a/untrusted_value_derive_internals/CHANGELOG.md
+++ b/untrusted_value_derive_internals/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive_internals-v0.2.1...untrusted_value_derive_internals-v0.2.2) - 2024-07-18
+
+### Added
+- introduced macro require_tainting
+
+### Other
+- moved traits/structs into own file each
+
 ## [0.2.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive_internals-v0.2.0...untrusted_value_derive_internals-v0.2.1) - 2024-07-17
 
 ### Fixed

--- a/untrusted_value_derive_internals/Cargo.toml
+++ b/untrusted_value_derive_internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value_derive_internals"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation", "taint", "static-analyis"]


### PR DESCRIPTION
## 🤖 New release
* `untrusted_value`: 0.2.1 -> 0.2.2
* `untrusted_value_derive`: 0.2.1 -> 0.2.2
* `untrusted_value_derive_internals`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `untrusted_value`
<blockquote>

## [0.2.2](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.2.1...untrusted_value-v0.2.2) - 2024-07-18

### Added
- introduced macro require_tainting

### Other
- moved traits/structs into own file each
</blockquote>

## `untrusted_value_derive`
<blockquote>

## [0.2.2](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.2.1...untrusted_value_derive-v0.2.2) - 2024-07-18

### Added
- introduced macro require_tainting

### Other
- moved traits/structs into own file each
</blockquote>

## `untrusted_value_derive_internals`
<blockquote>

## [0.2.2](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive_internals-v0.2.1...untrusted_value_derive_internals-v0.2.2) - 2024-07-18

### Added
- introduced macro require_tainting

### Other
- moved traits/structs into own file each
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).