### PR TITLE
chore: release

### DIFF
--- a/untrusted_value/CHANGELOG.md
+++ b/untrusted_value/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.3.0...untrusted_value-v0.3.1) - 2024-07-20
+
+### Added
+- added SanitizeValueEnd derive macro for #[untrusted_derive(...)]
+
 ## [0.3.0](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.2.4...untrusted_value-v0.3.0) - 2024-07-20
 
 ### Added

--- a/untrusted_value/Cargo.toml
+++ b/untrusted_value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation", "taint", "static-analyis"]
@@ -12,8 +12,8 @@ description = """This crate aim to provide a type-safe way to handle and sanitiz
 like user input."""
 
 [dependencies]
-untrusted_value_derive = { version = "0.3.0", optional = true, path = "../untrusted_value_derive"}
-untrusted_value_derive_internals = { version = "0.3.0", path = "../untrusted_value_derive_internals"}
+untrusted_value_derive = { version = "0.3.1", optional = true, path = "../untrusted_value_derive"}
+untrusted_value_derive_internals = { version = "0.3.1", path = "../untrusted_value_derive_internals"}
 
 [features]
 derive = [ "dep:untrusted_value_derive" ]

--- a/untrusted_value_derive/CHANGELOG.md
+++ b/untrusted_value_derive/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.3.0...untrusted_value_derive-v0.3.1) - 2024-07-20
+
+### Added
+- added SanitizeValueEnd derive macro for #[untrusted_derive(...)]
+
+### Other
+- fixed clippy warning
+
 ## [0.3.0](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.2.4...untrusted_value_derive-v0.3.0) - 2024-07-20
 
 ### Added

--- a/untrusted_value_derive/Cargo.toml
+++ b/untrusted_value_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value_derive"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation", "taint", "static-analyis"]

--- a/untrusted_value_derive_internals/CHANGELOG.md
+++ b/untrusted_value_derive_internals/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive_internals-v0.3.0...untrusted_value_derive_internals-v0.3.1) - 2024-07-20
+
+### Added
+- added SanitizeValueEnd derive macro for #[untrusted_derive(...)]
+
 ## [0.3.0](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive_internals-v0.2.4...untrusted_value_derive_internals-v0.3.0) - 2024-07-20
 
 ### Added

--- a/untrusted_value_derive_internals/Cargo.toml
+++ b/untrusted_value_derive_internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value_derive_internals"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation", "taint", "static-analyis"]


### PR DESCRIPTION
## 🤖 New release
* `untrusted_value`: 0.3.0 -> 0.3.1
* `untrusted_value_derive`: 0.3.0 -> 0.3.1
* `untrusted_value_derive_internals`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `untrusted_value`
<blockquote>

## [0.3.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.3.0...untrusted_value-v0.3.1) - 2024-07-20

### Added
- added SanitizeValueEnd derive macro for #[untrusted_derive(...)]
</blockquote>

## `untrusted_value_derive`
<blockquote>

## [0.3.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.3.0...untrusted_value_derive-v0.3.1) - 2024-07-20

### Added
- added SanitizeValueEnd derive macro for #[untrusted_derive(...)]

### Other
- fixed clippy warning
</blockquote>

## `untrusted_value_derive_internals`
<blockquote>

## [0.3.1](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive_internals-v0.3.0...untrusted_value_derive_internals-v0.3.1) - 2024-07-20

### Added
- added SanitizeValueEnd derive macro for #[untrusted_derive(...)]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).