### PR TITLE
chore: release v0.3.3

### DIFF
--- a/untrusted_value/CHANGELOG.md
+++ b/untrusted_value/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.3.2...untrusted_value-v0.3.3) - 2025-06-20
+
+### Other
+
+- updated the following local packages: untrusted_value_derive
+
 ## [0.3.2](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.3.1...untrusted_value-v0.3.2) - 2025-04-04
 
 ### Added

--- a/untrusted_value/Cargo.toml
+++ b/untrusted_value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation", "taint", "static-analyis"]
@@ -12,7 +12,7 @@ description = """This crate aim to provide a type-safe way to handle and sanitiz
 like user input."""
 
 [dependencies]
-untrusted_value_derive = { version = "0.3.2", optional = true, path = "../untrusted_value_derive"}
+untrusted_value_derive = { version = "0.3.3", optional = true, path = "../untrusted_value_derive"}
 untrusted_value_derive_internals = { version = "0.3.1", path = "../untrusted_value_derive_internals"}
 
 [features]

--- a/untrusted_value_derive/CHANGELOG.md
+++ b/untrusted_value_derive/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.3.2...untrusted_value_derive-v0.3.3) - 2025-06-20
+
+### Other
+
+- fixed cargo fmt suggestions
+- *(doc)* fixed cargo clippy errors
+
 ## [0.3.2](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.3.1...untrusted_value_derive-v0.3.2) - 2025-04-04
 
 ### Other

--- a/untrusted_value_derive/Cargo.toml
+++ b/untrusted_value_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "untrusted_value_derive"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 readme = "../README.md"
 keywords = ["security", "sanitization", "validation", "taint", "static-analyis"]


### PR DESCRIPTION



## 🤖 New release

* `untrusted_value_derive`: 0.3.2 -> 0.3.3
* `untrusted_value`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `untrusted_value_derive`

<blockquote>

## [0.3.3](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value_derive-v0.3.2...untrusted_value_derive-v0.3.3) - 2025-06-20

### Other

- fixed cargo fmt suggestions
- *(doc)* fixed cargo clippy errors
</blockquote>

## `untrusted_value`

<blockquote>

## [0.3.3](https://github.com/0xCCF4/UntrustedValue/compare/untrusted_value-v0.3.2...untrusted_value-v0.3.3) - 2025-06-20

### Other

- updated the following local packages: untrusted_value_derive
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).